### PR TITLE
Testing re-use graphs

### DIFF
--- a/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/formscreen/Register.kt
+++ b/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/formscreen/Register.kt
@@ -21,6 +21,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.TextView
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.android.navigationadvancedsample.R
@@ -37,7 +39,15 @@ class Register : Fragment() {
         val view = inflater.inflate(R.layout.fragment_register, container, false)
 
         view.findViewById<Button>(R.id.signup_btn).setOnClickListener {
-            findNavController().navigate(R.id.action_register_to_registered)
+            val userName = view.findViewById<TextView>(R.id.username_text).text.toString().run {
+                if (isBlank()) {
+                    "SomeUser"
+                } else {
+                    this
+                }
+            }
+            val bundle = bundleOf("userName" to userName)
+            findNavController().navigate(R.id.action_register_to_registered, bundle)
         }
         return view
     }

--- a/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/formscreen/Registered.kt
+++ b/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/formscreen/Registered.kt
@@ -20,7 +20,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import com.example.android.navigationadvancedsample.R
 
 /**
@@ -31,6 +34,12 @@ class Registered : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
 
-        return inflater.inflate(R.layout.fragment_registered, container, false)
+        val view = inflater.inflate(R.layout.fragment_registered, container, false)
+        view.findViewById<TextView>(R.id.done).text = arguments!!.getString("userName") + " registered"
+        view.findViewById<TextView>(R.id.done).setOnClickListener {
+            val bundle = bundleOf("userName" to arguments!!.getString("userName"))
+            findNavController().navigate(R.id.action_registered_to_userProfile, bundle)
+        }
+        return view
     }
 }

--- a/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/homescreen/Title.kt
+++ b/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/homescreen/Title.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.android.navigationadvancedsample.R
@@ -36,6 +37,10 @@ class Title : Fragment() {
 
         view.findViewById<Button>(R.id.about_btn).setOnClickListener {
             findNavController().navigate(R.id.action_title_to_about)
+        }
+        view.findViewById<Button>(R.id.my_profile).setOnClickListener {
+            val bundle = bundleOf("userName" to "My name")
+            findNavController().navigate(R.id.action_title_to_userProfile, bundle)
         }
         return view
     }

--- a/NavigationAdvancedSample/app/src/main/res/layout/fragment_registered.xml
+++ b/NavigationAdvancedSample/app/src/main/res/layout/fragment_registered.xml
@@ -26,9 +26,10 @@
     tools:layout_editor_absoluteY="81dp">
 
     <TextView
+        android:id="@+id/done"
         android:gravity="center_horizontal"
         android:layout_width="368dp"
-        android:layout_height="81dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"

--- a/NavigationAdvancedSample/app/src/main/res/layout/fragment_title.xml
+++ b/NavigationAdvancedSample/app/src/main/res/layout/fragment_title.xml
@@ -57,10 +57,28 @@
         android:textColor="@color/colorAccent"
         android:textSize="18sp"
         android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/my_profile"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title_image"/>
+
+    <Button
+        android:id="@+id/my_profile"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="144dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/rounded_button"
+        android:text="My profile"
+        android:textColor="@color/colorAccent"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/about_btn"/>
 
     <ImageView
         android:id="@+id/title_image"

--- a/NavigationAdvancedSample/app/src/main/res/navigation/form.xml
+++ b/NavigationAdvancedSample/app/src/main/res/navigation/form.xml
@@ -22,6 +22,8 @@
     android:id="@+id/form"
     app:startDestination="@id/register">
 
+    <include app:graph="@navigation/person" />
+
     <fragment
             android:id="@+id/register"
             android:name="com.example.android.navigationadvancedsample.formscreen.Register"
@@ -35,5 +37,12 @@
         android:id="@+id/registered"
         android:name="com.example.android.navigationadvancedsample.formscreen.Registered"
         android:label="Registered"
-        tools:layout="@layout/fragment_registered"/>
+        tools:layout="@layout/fragment_registered">
+        <action
+            android:id="@+id/action_registered_to_userProfile"
+            app:destination="@id/person" />
+        <argument
+            android:name="userName"
+            app:argType="string" />
+    </fragment>
 </navigation>

--- a/NavigationAdvancedSample/app/src/main/res/navigation/home.xml
+++ b/NavigationAdvancedSample/app/src/main/res/navigation/home.xml
@@ -22,6 +22,8 @@
     android:id="@+id/home"
     app:startDestination="@+id/titleScreen">
 
+    <include app:graph="@navigation/person" />
+
     <fragment
         android:id="@+id/titleScreen"
         android:name="com.example.android.navigationadvancedsample.homescreen.Title"
@@ -30,6 +32,9 @@
         <action
             android:id="@+id/action_title_to_about"
             app:destination="@id/aboutScreen"/>
+        <action
+            android:id="@+id/action_title_to_userProfile"
+            app:destination="@id/person"/>
     </fragment>
     <fragment
         android:id="@+id/aboutScreen"

--- a/NavigationAdvancedSample/app/src/main/res/navigation/list.xml
+++ b/NavigationAdvancedSample/app/src/main/res/navigation/list.xml
@@ -22,6 +22,8 @@
     android:id="@+id/list"
     app:startDestination="@+id/leaderboard">
 
+    <include app:graph="@navigation/person" />
+
     <fragment
             android:id="@+id/leaderboard"
             android:name="com.example.android.navigationadvancedsample.listscreen.Leaderboard"
@@ -29,19 +31,6 @@
             tools:layout="@layout/fragment_leaderboard">
         <action
             android:id="@+id/action_leaderboard_to_userProfile"
-            app:destination="@id/userProfile"/>
-    </fragment>
-    <fragment
-        android:id="@+id/userProfile"
-        android:name="com.example.android.navigationadvancedsample.listscreen.UserProfile"
-        android:label="@string/title_detail"
-        tools:layout="@layout/fragment_user_profile">
-        <deepLink
-            android:id="@+id/deepLink"
-            app:uri="www.example.com/user/{userName}"
-            android:autoVerify="true"/>
-        <argument
-            android:name="userName"
-            app:argType="string"/>
+            app:destination="@id/person"/>
     </fragment>
 </navigation>

--- a/NavigationAdvancedSample/app/src/main/res/navigation/person.xml
+++ b/NavigationAdvancedSample/app/src/main/res/navigation/person.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/person"
+    app:startDestination="@id/userProfile">
+
+    <fragment
+        android:id="@+id/userProfile"
+        android:name="com.example.android.navigationadvancedsample.listscreen.UserProfile"
+        android:label="@string/title_detail"
+        tools:layout="@layout/fragment_user_profile">
+        <deepLink
+            android:id="@+id/deepLink"
+            android:autoVerify="true"
+            app:uri="www.example.com/user/{userName}" />
+        <argument
+            android:name="userName"
+            app:argType="string" />
+    </fragment>
+</navigation>


### PR DESCRIPTION
Added a separate profile nav_graph which can be reached from all other nav_graphs because it is included.
Functional changes:
- Home screen contains a "my profile" button, navigating to your profile page
- Registered now shows the name you've registered on. Clicking on it moves to a profile page with that name
Note: profile pages are the same screen as a profile from the leaderboard, same fragment, same nav_graph and all.

Possible issues:
- [ ] home remembers it's own backstack (which is fine). When you navigate back from another tab you arrive in the home backstack instead of the main/home screen: `home > about > register (via tab) > leaderboard (via tab) > profile > back (=leaderboard) > back (=about)`. We probably want a back navigation from a tab to move to the root of the home nav_graph: `home > about > register (via tab) > leaderboard (via tab) > profile > back (leaderboard) > back (home)`
- [ ] check with designer: navigation to an included nav_graph should always be saved on top of the current tab's backstack. So if we open a profile page on home, THEN a profile page via leaderboard THEN a profile page via register, we probably want them all to be saved on separate backstack, so if we navigate through tabs we'll see different profile pages.